### PR TITLE
Increase processing speed by 5x

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,18 +11,15 @@ pub fn bytevec_tohex(vector: &Vec<u8>, upper: bool) -> String {
 	hex
 }
 
-pub fn xor_hasher<T: std::iter::Iterator<Item = Result<u8, std::io::Error>>>(
-	bytes: T,
-	key: &mut Vec<u8>,
+pub fn xor_hasher(
+	bytes: &[u8],
+	key: &mut [u8],
 ) {
-	(0..key.len())
-		.cycle()
-		.zip(bytes)
-		.for_each(|(kb_idx, b)| {
-			//Safety: We are using `kb_idx` to index into the key
-			//and it is bound between 0 and key.len()
-			*unsafe { key.get_unchecked_mut(kb_idx) } ^= b.as_ref().unwrap();
-		})
+	for chunk in bytes.chunks(key.len()) {
+		chunk.iter()
+			.zip(&mut *key)
+			.for_each(|(&b, k)| *k ^= b);
+	}
 }
 
 fn rng(m: usize) -> usize {


### PR DESCRIPTION
Quoting @Measter :
> This is done by ensuring that the BufReader's buffer is filled first, then processing the entire buffer in one chunk.
>
> The way it was previously done, each byte was a fallible read, meaning the byte it failed on was observable. Because of that, the compiler was unable to further optimize the processing to make use SIMD instructions.

[Reddit comment](https://reddit.com/r/rust/comments/w7gt6v/comment/ihpqd0k/?utm_source=share&utm_medium=web2x&context=3)

I noticed [there's a ceiling-div](https://github.com/Measter/xorsum/blob/c9b8553dae53e53b88d6778c4c75080abec66d73/src/main.rs#L95), and tried to search for a built-in function, but [it doesn't exist yet](https://github.com/rust-lang/rfcs/issues/2844)

Related issues: #16